### PR TITLE
feat: add DNSBL (RBL) proxy filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Collect, test, and organize HTTP/SOCKS4/SOCKS5 proxies from multiple sources wit
 - **🔥 Blazing Performance** - Rust-powered async engine with configurable concurrency
 - **🌍 Rich Metadata** - ASN, country/city geolocation, and response time data via offline MaxMind databases
 - **🎯 Smart Parsing** - Advanced regex engine extracts proxies from any format (`protocol://user:pass@host:port`). Also supports CIDR notation (e.g. `192.168.0.0/24`), automatically expanding ranges into individual hosts.
+- **🛡️ DNSBL Filtering** - Automatically filter out bad proxies using DNS-based Blackhole Lists (RBL) like `dnsbl.dronebl.org`. Checks both host and exit IPs.
 - **🔐 Auth Support** - Handles username/password authentication seamlessly
 - **📊 Interactive TUI** - Real-time progress monitoring with beautiful terminal interface
 - **⚡ Flexible Output** - JSON (with metadata) and plain text formats

--- a/config-schema.json
+++ b/config-schema.json
@@ -79,7 +79,21 @@
         "max_concurrent_checks": { "type": "integer", "minimum": 1 },
         "timeout": { "type": "number", "minimum": 0 },
         "connect_timeout": { "type": "number", "minimum": 0 },
-        "user_agent": { "type": "string" }
+        "user_agent": { "type": "string" },
+        "dnsbl": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "lists": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1, "pattern": "\\S" }
+            },
+            "check_host": { "type": "boolean" },
+            "check_exit_ip": { "type": "boolean" },
+            "strict": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
       },
       "required": [
         "check_url",

--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,21 @@ connect_timeout = 5.0
 # User-Agent header for proxy check requests
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
 
+[checking.dnsbl]
+# Enable DNSBL (RBL) filtering
+enabled = false
+# List of DNSBL domains to check against
+lists = ["dnsbl.dronebl.org"]
+# Check the proxy host IP against DNSBLs
+check_host = true
+# Check the proxy exit IP against DNSBLs
+# Requires `checking.check_url` to return the caller IP.
+# Connectivity-only endpoints do not produce an exit IP, so this check is skipped for them.
+check_exit_ip = true
+# If true, drop the proxy when the DNS lookup fails or times out.
+# If false, allow the proxy to pass the DNSBL check on lookup failure (recommended to avoid false positives during rate-limiting).
+strict = false
+
 [scraping]
 # Maximum proxies to collect per source (0 = unlimited)
 # When this limit is reached, the source is skipped with a warning to prevent memory issues

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -4,20 +4,21 @@ use color_eyre::eyre::OptionExt as _;
 
 #[cfg(feature = "tui")]
 use crate::event::{AppEvent, Event};
-use crate::{config::Config, proxy::Proxy, utils::pretty_error};
+use crate::{
+    config::Config, http::HickoryDnsResolver, proxy::Proxy, utils::pretty_error,
+};
 
-pub async fn check_all<R>(
+pub async fn check_all(
     config: Arc<Config>,
-    dns_resolver: R,
+    dns_resolver: HickoryDnsResolver,
     proxies: Vec<Proxy>,
     mut tls_backend: rustls::ClientConfig,
     token: tokio_util::sync::CancellationToken,
     #[cfg(feature = "tui")] tx: tokio::sync::mpsc::UnboundedSender<Event>,
-) -> crate::Result<Vec<Proxy>>
-where
-    R: reqwest::dns::Resolve + Clone + 'static,
-{
-    if config.checking.check_url.is_none() {
+) -> crate::Result<Vec<Proxy>> {
+    if config.checking.check_url.is_none()
+        && !(config.checking.dnsbl.enabled && config.checking.dnsbl.check_host)
+    {
         return Ok(proxies);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,12 +34,22 @@ pub struct ScrapingConfig {
     pub sources: HashMap<ProxyType, Vec<Arc<Source>>>,
 }
 
+#[expect(clippy::struct_excessive_bools)]
+pub struct DnsblConfig {
+    pub enabled: bool,
+    pub lists: Vec<compact_str::CompactString>,
+    pub check_host: bool,
+    pub check_exit_ip: bool,
+    pub strict: bool,
+}
+
 pub struct CheckingConfig {
     pub check_url: Option<url::Url>,
     pub max_concurrent_checks: usize,
     pub timeout: Duration,
     pub connect_timeout: Duration,
     pub user_agent: compact_str::CompactString,
+    pub dnsbl: DnsblConfig,
 }
 
 pub struct TxtOutputConfig {
@@ -139,6 +149,8 @@ impl Config {
                 raw_config.checking.max_concurrent_checks.get()
             };
 
+        let check_url_is_none = raw_config.checking.check_url.is_none();
+
         Ok(Self {
             debug: raw_config.debug,
             scraping: ScrapingConfig {
@@ -180,6 +192,43 @@ impl Config {
                     raw_config.checking.connect_timeout,
                 ),
                 user_agent: raw_config.checking.user_agent,
+                dnsbl: {
+                    let dnsbl = raw_config.checking.dnsbl;
+                    let cleaned_lists: Vec<compact_str::CompactString> = dnsbl
+                        .lists
+                        .into_iter()
+                        .map(|s| compact_str::CompactString::from(s.trim()))
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    if dnsbl.enabled {
+                        if !dnsbl.check_host && !dnsbl.check_exit_ip {
+                            return Err(color_eyre::eyre::eyre!(
+                                "DNSBL is enabled but both \
+                                 'checking.dnsbl.check_host' and \
+                                 'checking.dnsbl.check_exit_ip' are false"
+                            ));
+                        }
+                        if dnsbl.check_exit_ip && check_url_is_none {
+                            return Err(color_eyre::eyre::eyre!(
+                                "DNSBL exit-IP checks require \
+                                 'checking.check_url'"
+                            ));
+                        }
+                        if cleaned_lists.is_empty() {
+                            return Err(color_eyre::eyre::eyre!(
+                                "DNSBL is enabled but no valid list entries \
+                                 are configured"
+                            ));
+                        }
+                    }
+                    DnsblConfig {
+                        enabled: dnsbl.enabled,
+                        lists: cleaned_lists,
+                        check_host: dnsbl.check_host,
+                        check_exit_ip: dnsbl.check_exit_ip,
+                        strict: dnsbl.strict,
+                    }
+                },
             },
             output: OutputConfig {
                 path: output_path,

--- a/src/http.rs
+++ b/src/http.rs
@@ -47,6 +47,25 @@ impl HickoryDnsResolver {
             hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
         Ok(Self(Arc::new(builder.build()?)))
     }
+
+    pub async fn lookup_ip(
+        &self,
+        query: &str,
+    ) -> crate::Result<hickory_resolver::lookup_ip::LookupIp> {
+        Ok(self.0.lookup_ip(query).await?)
+    }
+
+    /// Like `lookup_ip`, but preserves the raw `NetError` for structured
+    /// matching.
+    pub async fn lookup_ip_raw(
+        &self,
+        query: &str,
+    ) -> Result<
+        hickory_resolver::lookup_ip::LookupIp,
+        hickory_resolver::net::NetError,
+    > {
+        self.0.lookup_ip(query).await
+    }
 }
 
 impl reqwest::dns::Resolve for HickoryDnsResolver {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -119,15 +119,22 @@ impl ProxySink for Vec<u8> {
 }
 
 impl Proxy {
-    pub async fn check<R>(
+    pub async fn check(
         &mut self,
         config: &Config,
-        dns_resolver: R,
+        dns_resolver: crate::http::HickoryDnsResolver,
         tls_backend: rustls::ClientConfig,
-    ) -> crate::Result<()>
-    where
-        R: reqwest::dns::Resolve + 'static,
-    {
+    ) -> crate::Result<()> {
+        if config.checking.dnsbl.enabled && config.checking.dnsbl.check_host {
+            Self::check_dnsbl(
+                &self.host,
+                &config.checking.dnsbl.lists,
+                &dns_resolver,
+                config.checking.dnsbl.strict,
+            )
+            .await?;
+        }
+
         let Some(check_url) = config.checking.check_url.clone() else {
             return Ok(());
         };
@@ -144,7 +151,7 @@ impl Proxy {
             .tcp_keepalive_interval(None)
             .tcp_keepalive_retries(None)
             .tls_backend_preconfigured(tls_backend)
-            .dns_resolver(dns_resolver)
+            .dns_resolver(dns_resolver.clone())
             .build()?
             .get(check_url);
 
@@ -152,7 +159,7 @@ impl Proxy {
         let response = request.send().await?.error_for_status()?;
 
         self.timeout = Some(start.elapsed());
-        self.exit_ip = response.text().await.map_or(None, |text| {
+        let exit_ip_str = response.text().await.map_or(None, |text| {
             if let Ok(httpbin) = serde_json::from_str::<HttpbinResponse>(&text)
             {
                 parse_ipv4(&httpbin.origin)
@@ -160,7 +167,94 @@ impl Proxy {
                 parse_ipv4(&text)
             }
         });
+        self.exit_ip.clone_from(&exit_ip_str);
 
+        if config.checking.dnsbl.enabled
+            && config.checking.dnsbl.check_exit_ip
+            && let Some(exit_ip) = exit_ip_str
+        {
+            Self::check_dnsbl(
+                &exit_ip,
+                &config.checking.dnsbl.lists,
+                &dns_resolver,
+                config.checking.dnsbl.strict,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn check_dnsbl(
+        host_or_ip: &str,
+        dnsbl_lists: &[compact_str::CompactString],
+        dns_resolver: &crate::http::HickoryDnsResolver,
+        strict: bool,
+    ) -> crate::Result<()> {
+        let candidates =
+            if let Ok(ipv4) = std::net::Ipv4Addr::from_str(host_or_ip) {
+                vec![ipv4]
+            } else {
+                match dns_resolver.lookup_ip(host_or_ip).await {
+                    Ok(response) => response
+                        .iter()
+                        .filter_map(|ip| match ip {
+                            std::net::IpAddr::V4(v4) => Some(v4),
+                            std::net::IpAddr::V6(_) => None,
+                        })
+                        .collect(),
+                    Err(e) => {
+                        if strict {
+                            return Err(eyre!(
+                                "DNSBL host resolution failed for {}: {}",
+                                host_or_ip,
+                                e
+                            ));
+                        }
+                        vec![]
+                    }
+                }
+            };
+
+        for ipv4 in candidates {
+            let octets = ipv4.octets();
+            let reversed = compact_str::format_compact!(
+                "{}.{}.{}.{}",
+                octets[3],
+                octets[2],
+                octets[1],
+                octets[0]
+            );
+            for list in dnsbl_lists {
+                let list = list.trim_end_matches('.');
+                let query = compact_str::format_compact!("{reversed}.{list}.");
+                match dns_resolver.lookup_ip_raw(&query).await {
+                    Ok(response) => {
+                        if response.iter().next().is_some() {
+                            return Err(eyre!(
+                                "IP {} is blacklisted in {}",
+                                ipv4,
+                                list
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        if e.is_no_records_found() || e.is_nx_domain() {
+                            // NXDOMAIN or no records means the IP is clean
+                            continue;
+                        }
+                        if strict {
+                            return Err(eyre!(
+                                "DNSBL {} lookup failed for IP {}: {}",
+                                list,
+                                ipv4,
+                                e
+                            ));
+                        }
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/src/raw_config.rs
+++ b/src/raw_config.rs
@@ -125,6 +125,21 @@ pub struct ScrapingConfig {
     pub socks5: ScrapingProtocolConfig,
 }
 
+#[derive(Default, serde::Deserialize)]
+#[expect(clippy::struct_excessive_bools)]
+pub struct DnsblConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub lists: Vec<compact_str::CompactString>,
+    #[serde(default)]
+    pub check_host: bool,
+    #[serde(default)]
+    pub check_exit_ip: bool,
+    #[serde(default)]
+    pub strict: bool,
+}
+
 #[derive(serde::Deserialize)]
 pub struct CheckingConfig {
     #[serde(deserialize_with = "validate_http_url")]
@@ -135,6 +150,8 @@ pub struct CheckingConfig {
     #[serde(deserialize_with = "validate_positive_f64")]
     pub connect_timeout: f64,
     pub user_agent: compact_str::CompactString,
+    #[serde(default)]
+    pub dnsbl: DnsblConfig,
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
Key changes:
- Added `DnsblConfig` to handle DNSBL settings (enabled, lists, check_host, check_exit_ip, strict).
- Extended `HickoryDnsResolver` to support asynchronous `lookup_ip` queries.
- Intercepted the proxy checking flow in `Proxy::check` to optionally query the RBL for the proxy's host IP and/or exit IP.
- Added a `strict` mode to control whether a proxy should be dropped or allowed when a DNS query times out or fails (protects against aggressive rate-limiting from public RBLs).
- Updated `config.toml`, `config-schema.json`, and `README.md` to reflect the new feature.